### PR TITLE
fix: use correct multiline output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,4 +11,4 @@ if ($INPUT_MULTILINE); then
   OUTPUT="${OUTPUT//$'\r'/'%0D'}"
 fi
 
-echo "::set-output name=value::$(eval $INPUT_CMD)"
+echo "::set-output name=value::$OUTPUT"


### PR DESCRIPTION
Small fix to get multiline output to actually work. The original PR that added this support didn't actually have the full solution in.